### PR TITLE
fix: Add secretmanager permissions for GitHub Actions service accounts

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -30,3 +30,11 @@ resource "google_project_iam_member" "radiocast_monitoring" {
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.radiocast.email}"
 }
+
+# GitHub Actions service account permissions for secret access during deployment
+resource "google_project_iam_member" "github_actions_secrets" {
+  count   = var.github_actions_sa_email != "" ? 1 : 0
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${var.github_actions_sa_email}"
+}

--- a/terraform/prod/prod.tfvars
+++ b/terraform/prod/prod.tfvars
@@ -15,3 +15,6 @@ timeout       = "600s"
 
 # Enable monitoring for production
 enable_monitoring = true
+
+# GitHub Actions service account for deployment
+github_actions_sa_email = "radiocast-prod-deploy@dfh-prod-id.iam.gserviceaccount.com"

--- a/terraform/stage/stage.tfvars
+++ b/terraform/stage/stage.tfvars
@@ -15,3 +15,6 @@ timeout       = "300s"
 
 # Monitoring disabled for staging
 enable_monitoring = false
+
+# GitHub Actions service account for deployment
+github_actions_sa_email = "radiocast-stage-deploy@dfh-stage-id.iam.gserviceaccount.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,3 +89,9 @@ variable "radiocast_retention_days" {
   type        = number
   default     = 180
 }
+
+variable "github_actions_sa_email" {
+  description = "Email of the GitHub Actions service account that needs to read secrets during deployment"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- Added github_actions_sa_email variable to terraform configuration
- Granted secretmanager.secretAccessor role to GitHub Actions service accounts
- Applied to both staging and production environments
- Fixes terraform deployment failures due to permission denied errors
