### PR TITLE
Fix Cloud Scheduler Authentication Issue

### DIFF
--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -16,10 +16,6 @@ resource "google_cloud_scheduler_job" "daily_report" {
       "Content-Type"  = "application/json"
       "Authorization" = "Bearer ${var.radiocast_api_key}"
     }
-
-    oidc_token {
-      service_account_email = google_service_account.radiocast.email
-    }
   }
 
   retry_config {


### PR DESCRIPTION
## 🔧 Fix: Cloud Scheduler Authentication Issue

### Problem
The GCP Cloud Scheduler was failing with 401 authentication errors when trying to generate daily reports:
- Error: `URL_ERROR-ERROR_AUTHENTICATION. Original HTTP response code number = 401`
- Root cause: Conflicting authentication methods in scheduler configuration

### Root Cause Analysis
The `scheduler.tf` was configured with BOTH:
1. Custom Authorization header: `Authorization: Bearer ${var.radiocast_api_key}`
2. OIDC token authentication: `oidc_token { service_account_email = ... }`

When using `oidc_token`, Google Cloud Scheduler automatically adds its own Authorization header with the OIDC token, which overwrote the custom API key header, causing authentication to fail.

### Solution
- ✅ **Removed conflicting `oidc_token` block** from scheduler.tf
- ✅ **Kept only the custom Authorization header** with radiocast API key  
- ✅ **Tested and verified** - Manual API call returns HTTP 200 with successful report generation

### Files Changed
- `terraform/scheduler.tf` - Removed 4 lines of conflicting OIDC configuration

### Testing
- ✅ **Staging Environment**: Applied and tested successfully
- ✅ **Manual API Test**: `curl -X POST https://radiocast-stage-c3ugnmjtaa-uc.a.run.app/generate` returns 200
- ✅ **Report Generation**: Successfully created report folder `2025-09-21_22-03-35`

### Impact
- 🎯 **Fixes automated daily report generation** in GCP environments
- 🔒 **Maintains security** with proper API key authentication
- 📅 **Enables reliable scheduling** for daily reports at midnight UTC

This fix ensures the Cloud Scheduler can successfully authenticate and generate daily radio propagation reports automatically.